### PR TITLE
wip: ignore dev code artifacts for CSS only updates

### DIFF
--- a/packages/vite-plugin-svelte/src/handleHotUpdate.ts
+++ b/packages/vite-plugin-svelte/src/handleHotUpdate.ts
@@ -14,7 +14,6 @@ export async function handleHotUpdate(
   cache: VitePluginSvelteCache
 ): Promise<ModuleNode[] | void> {
   const { read, server } = ctx
-  const { cssHash } = svelteRequest
   const cachedCompileData = cache.getCompileData(svelteRequest, false)
   if (!cachedCompileData) {
     // file hasn't been requested yet (e.g. async component)
@@ -39,7 +38,7 @@ export async function handleHotUpdate(
     affectedModules.add(cssModule)
   }
 
-  if (mainModule && jsChanged(cssHash, cachedCompileData, compileData)) {
+  if (mainModule && jsChanged(cachedCompileData, compileData)) {
     log.debug('handleHotUpdate js changed')
     affectedModules.add(mainModule)
   }
@@ -63,36 +62,24 @@ export async function handleHotUpdate(
   return result
 }
 
-function normalizeNonCss(code: string, cssHash: string) {
+function normalizeNonCss(code: string) {
   // trim HMR transform
   const indexHmrTransform = code.indexOf(
     'import * as ___SVELTE_HMR_HOT_API from'
   )
   if (indexHmrTransform !== -1) code = code.slice(0, indexHmrTransform)
-  // remove irrelevant bits
-  // NOTE the closer we're making our regexes to what we know of the compiler's
-  //      output, the more fragile we are, but the less we risk catching
-  //      similarly looking user's code
-  return (
-    code
-      // ignore css hashes in the code (that have changed, necessarily)
-      .replace(new RegExp('\\s*\\b' + cssHash + '\\b\\s*', 'g'), '')
-      // TODO this one might need to be a little more specific
-      .replace(/\s*attr_dev\([^,]+,\s*"class",\s*""\);?\s*/g, '')
-      // Svelte now adds locations in dev mode, code locations can change when
-      // CSS change, but we're unaffected (not real behaviour changes)
-      .replace(/\s*\badd_location\s*\([^)]*\)\s*;?/g, '')
-  )
+  // remove add_location -- changes but has no real world usage currently
+  return code.replace(/\s*\badd_location\s*\([^)]*\)\s*;?/g, '')
 }
 
 function cssChanged(prev: CompileData, next: CompileData) {
   return !isCodeEqual(prev.compiled.css?.code, next.compiled.css?.code)
 }
 
-function jsChanged(hash: string, prev: CompileData, next: CompileData) {
+function jsChanged(prev: CompileData, next: CompileData) {
   return !isCodeEqual(
-    normalizeNonCss(prev.compiled.js?.code, hash),
-    normalizeNonCss(next.compiled.js?.code, hash)
+    normalizeNonCss(prev.compiled.js?.code),
+    normalizeNonCss(next.compiled.js?.code)
   )
 }
 

--- a/packages/vite-plugin-svelte/src/utils/compile.ts
+++ b/packages/vite-plugin-svelte/src/utils/compile.ts
@@ -3,7 +3,6 @@ import { compile, preprocess, walk } from 'svelte/compiler'
 // @ts-ignore
 import { createMakeHot } from 'svelte-hmr'
 import { SvelteRequest } from './id'
-import { safeBase64Hash } from './hash'
 import { log } from './log'
 
 const _createCompileSvelte = (makeHot: Function) =>
@@ -23,7 +22,7 @@ const _createCompileSvelte = (makeHot: Function) =>
       hydratable: true
     }
     if (options.hot) {
-      const hash = `s-${safeBase64Hash(cssId)}`
+      const hash = svelteRequest.cssHash
       log.debug(`setting cssHash ${hash} for ${cssId}`)
       finalCompilerOptions.cssHash = () => hash
     }

--- a/packages/vite-plugin-svelte/src/utils/id.ts
+++ b/packages/vite-plugin-svelte/src/utils/id.ts
@@ -2,6 +2,7 @@
 import qs from 'querystring'
 import { createFilter } from '@rollup/pluginutils'
 import { Arrayable, ResolvedOptions } from './options'
+import { safeBase64Hash } from './hash'
 
 export type SvelteQueryTypes = 'style' | 'script'
 
@@ -16,6 +17,7 @@ export interface SvelteQuery {
 export interface SvelteRequest {
   id: string
   cssId: string
+  cssHash: string
   filename: string
   normalizedFilename: string
   query: SvelteQuery
@@ -45,6 +47,7 @@ function parseToSvelteRequest(
   return {
     id,
     cssId,
+    cssHash: `s-${safeBase64Hash(cssId)}`,
     filename,
     normalizedFilename,
     query,


### PR DESCRIPTION
Filter out dev only code for the CSS only test, enabling more CSS only updates.

We'd still need to make this feature optional (opt out, I'd say), because the implementation is not risk free. There are some rare corner cases where we will collide with user code (resulting in CSS only updates, where a true one was expected).