### PR TITLE
make WindiCSS templates work again

### DIFF
--- a/packages/templates/windicss-ts/vite.config.js
+++ b/packages/templates/windicss-ts/vite.config.js
@@ -1,16 +1,13 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { defineConfig } from 'vite'
-import vitePluginWindicss from 'vite-plugin-windicss'
+import WindiCSS from 'vite-plugin-windicss'
 
 export default defineConfig(({ command, mode }) => {
   const isProduction = mode === 'production'
   return {
     plugins: [
-      // uses enforce: pre
       svelte(),
-      vitePluginWindicss.default({
-        transformCSS: 'pre'
-      })
+      WindiCSS()
     ],
     build: {
       minify: isProduction

--- a/packages/templates/windicss/vite.config.js
+++ b/packages/templates/windicss/vite.config.js
@@ -1,16 +1,13 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { defineConfig } from 'vite'
-import vitePluginWindicss from 'vite-plugin-windicss'
+import WindiCSS from 'vite-plugin-windicss'
 
 export default defineConfig(({ command, mode }) => {
   const isProduction = mode === 'production'
   return {
     plugins: [
-      // uses enforce: pre
       svelte({}),
-      vitePluginWindicss.default({
-        transformCSS: 'pre'
-      })
+      WindiCSS()
     ],
     build: {
       minify: isProduction


### PR DESCRIPTION
Am sorry if this is something really dumb, but running dev would throw windicss errors that vitepluginwindicss doesn't exist, looked at theirs docs and they said to use it like this and, well, it works.
Maybe a new version?
again sorry if am just completely doing something dumb right now. 

EDIT: SO it wouldn't work, the preprocessor has to be added, `yarn add svelte-windicss-preprocess` and:
![image](https://user-images.githubusercontent.com/32438954/139493217-e3abc69f-e3b2-4695-9409-18757c312baf.png)
I guess that was the `pre` in the original? But as said, it didn't work, might be a new version. Or again, am just really dumb here, I've never used windi
This could have definitely worked better as an issue!